### PR TITLE
Added aarch64-darwin as a supported system for nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
       supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
+        "aarch64-darwin"
       ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 


### PR DESCRIPTION
Hello, please kindly add aarch64-darwin as a supported system in nix flake. I have tested this locally and was able to build the project, then integrate it with helix editor. Merging this will allow me and others to use on Mac arm hardware. Thanks!