### PR TITLE
feat: support hypertext `maud` macros

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -19,7 +19,16 @@ impl Default for FormatOptions {
     fn default() -> Self {
         FormatOptions {
             line_length: 100,
-            macro_names: vec![String::from("maud::html"), String::from("html")],
+            macro_names: vec![
+                String::from("maud::html"),
+                String::from("html"),
+                String::from("hypertext::maud"),
+                String::from("maud"),
+                String::from("hypertext::maud_borrow"),
+                String::from("maud_borrow"),
+                String::from("hypertext::maud_static"),
+                String::from("maud_static"),
+            ],
         }
     }
 }

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -101,4 +101,28 @@ mod test {
         "maud::html!{ }",
         "maud::html! {}"
     );
+
+    test_default!(
+        hypertext_maud_empty,
+        "hypertext::maud!{ }",
+        "hypertext::maud! {}"
+    );
+
+    test_default!(
+        hypertext_maud_borrow_empty,
+        "hypertext::maud_borrow!{ }",
+        "hypertext::maud_borrow! {}"
+    );
+
+    test_default!(
+        hypertext_maud_static_empty,
+        "hypertext::maud_static!{ }",
+        "hypertext::maud_static! {}"
+    );
+
+    test_default!(maud_empty, "maud!{ }", "maud! {}");
+
+    test_default!(maud_borrow_empty, "maud_borrow!{ }", "maud_borrow! {}");
+
+    test_default!(maud_static_empty, "maud_static!{ }", "maud_static! {}");
 }


### PR DESCRIPTION
Add support for hypertext `maud` macros: https://github.com/vidhanio/hypertext

Addresses #46.