### PR TITLE
feat: add maudfmt-ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ p {
 }
 ```
 
+### Skip formatting for a single line
+
+To skip formatting for just one line, add a `// maudfmt-ignore` comment on the line before:
+
+```
+html! {
+    p { "formatted" }
+    // maudfmt-ignore
+    span class="unformatted"   id="test" { "content" }
+    h1 { "also formatted" }
+}
+```
+
 ### Magic comments
 
 _maudfmt_ automatically manages exanding and collapsing blocks depending on line length.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,20 @@ use vendor::ast;
 pub use format::FormatOptions;
 
 pub fn try_fmt_file(source: &str, options: &format::FormatOptions) -> Result<String> {
-    let ast = syn::parse_file(source).context("Failed to parse source")?;
-    let rope = Rope::from(source);
+    let (processed_source, ignore_info) = format::preprocess_source_for_ignore(source);
+
+    let ast = syn::parse_file(&processed_source).context("Failed to parse source")?;
+    let rope = Rope::from(processed_source);
     let (mut rope, macros) = collect::collect_macros_from_file(&ast, rope, &options.macro_names);
-    Ok(format::format_source(&mut rope, macros, options))
+    let formatted_processed = format::format_source(&mut rope, macros, options);
+
+    // Reinsert ignored lines if any
+    if ignore_info.is_empty() {
+        Ok(formatted_processed)
+    } else {
+        Ok(format::reinsert_ignored_lines_in_source(
+            &formatted_processed,
+            &ignore_info,
+        ))
+    }
 }


### PR DESCRIPTION
Adds `// maudfmt-ignore` directive to ignore formatting on the single subsequent line.

```rust
html! {
    p { "formatted" }
    // maudfmt-ignore
    p class =  "abc" {"will not be formatted"   }
}
```