### PR TITLE
feat: add `--macro-names` argument to specify custom macro names

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ Arguments:
   [FILE]...  A space separated list of file, directory or glob
 
 Options:
-  -s, --stdin    Format stdin and write to stdout
-  -h, --help     Print help
-  -V, --version  Print version
+  -s, --stdin                      Format stdin and write to stdout
+  -m, --macro-names <MACRO_NAMES>  Override macro names to format [default: html maud::html]
+  -h, --help                       Print help
+  -V, --version                    Print version
 ```
 
 <!-- help end -->

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,19 @@ struct Cli {
     /// Format stdin and write to stdout
     #[arg(short, long, default_value = "false")]
     stdin: bool,
+
+    /// Override macro names to format
+    #[arg(short, long, value_delimiter = ',', default_values = ["html", "maud::html"])]
+    macro_names: Vec<String>,
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let format_options = FormatOptions::default();
+    let format_options = FormatOptions {
+        line_length: 100,
+        macro_names: cli.macro_names,
+    };
 
     if cli.stdin {
         let buf = {


### PR DESCRIPTION
Add `--macro-names` argument to address #46:

```bash
An opinionated yet customizable Maud formatter.

Usage: maudfmt [OPTIONS] [FILE]...

Arguments:
  [FILE]...  A space separated list of file, directory or glob

Options:
  -s, --stdin                      Format stdin and write to stdout
  -m, --macro-names <MACRO_NAMES>  Override macro names to format [default: html maud::html]
  -h, --help                       Print help
  -V, --version                    Print version
```