### PR TITLE
feat: add --line-length

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Options:
   -s, --stdin                      Format stdin and write to stdout
   -m, --macro-names <MACRO_NAMES>  Comma-separated list of macro names (overriding html and maud::html)
       --rustfmt                    Run rustfmt after maudfmt
+      --line-length <LINE_LENGTH>  Maximum line length
   -h, --help                       Print help
   -V, --version                    Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,10 @@ struct Cli {
     /// Run rustfmt after maudfmt
     #[arg(long, default_value = "false")]
     rustfmt: bool,
+
+    /// Maximum line length
+    #[arg(long)]
+    line_length: Option<usize>,
 }
 
 fn main() -> Result<()> {
@@ -36,6 +40,9 @@ fn main() -> Result<()> {
     let mut format_options = FormatOptions::default();
     if let Some(macro_names) = cli.macro_names {
         format_options.macro_names = macro_names;
+    }
+    if let Some(line_length) = cli.line_length {
+        format_options.line_length = line_length;
     }
 
     if cli.stdin {


### PR DESCRIPTION
Add `--line-length` CLI argument to customise line length. Addresses #66.