### PR TITLE
feat: sort Tailwind CSS classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +133,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +192,19 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compact_str"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "static_assertions",
+ "zmij",
+]
 
 [[package]]
 name = "crop"
@@ -212,6 +253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +266,16 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -234,6 +291,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -267,6 +342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,10 +370,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
@@ -305,6 +398,15 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -328,6 +430,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
+ "rustywind_core",
  "syn",
 ]
 
@@ -363,6 +466,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "predicates"
@@ -436,12 +562,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick_cache"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403c1a912fec895cafb223201e368234842acb9220aaf08ab042ae89ba5f135c"
+dependencies = [
+ "equivalent",
+ "foldhash",
+ "hashbrown",
+ "parking_lot",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -487,6 +640,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rustywind_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1a32bbc494781e082b6cb765d4422683f457fb42e42b4c80687800e158170b"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "eyre",
+ "once_cell",
+ "quick_cache",
+ "regex",
+ "winnow",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +669,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde_core"
@@ -514,6 +695,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_indices"
@@ -594,6 +787,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,7 +820,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro2 = { version = "1", features = ["span-locations"] }
 prettyplease = { version = "0.2", features = ["verbatim"] }
 proc-macro2-diagnostics = { version = "0.10", default-features = false }
 quote = "1"
+rustywind_core = "0.5"
 syn = { version = "2", features = ["visit", "full", "extra-traits"] }
 # keep-sorted end
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Options:
   -m, --macro-names <MACRO_NAMES>  Comma-separated list of macro names (overriding html and maud::html)
       --rustfmt                    Run rustfmt after maudfmt
       --line-length <LINE_LENGTH>  Maximum line length
+      --tailwindcss                Sort Tailwind CSS classes
   -h, --help                       Print help
   -V, --version                    Print version
 ```

--- a/src/format.rs
+++ b/src/format.rs
@@ -15,6 +15,7 @@ const IGNORE_PLACEHOLDER: &str = "\"__MAUDFMT_IGNORED_PLACEHOLDER__\"";
 pub struct FormatOptions {
     pub line_length: usize,
     pub macro_names: Vec<String>,
+    pub tailwindcss: bool,
 }
 
 impl Default for FormatOptions {
@@ -22,6 +23,7 @@ impl Default for FormatOptions {
         FormatOptions {
             line_length: 100,
             macro_names: vec![String::from("maud::html"), String::from("html")],
+            tailwindcss: false,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod collect;
 mod format;
 mod line_length;
 mod print;
+mod tailwind;
 mod unparse;
 mod vendor;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,10 @@ struct Cli {
     /// Maximum line length
     #[arg(long)]
     line_length: Option<usize>,
+
+    /// Sort Tailwind CSS classes
+    #[arg(long, default_value = "false")]
+    tailwindcss: bool,
 }
 
 fn main() -> Result<()> {
@@ -43,6 +47,9 @@ fn main() -> Result<()> {
     }
     if let Some(line_length) = cli.line_length {
         format_options.line_length = line_length;
+    }
+    if cli.tailwindcss {
+        format_options.tailwindcss = true;
     }
 
     if cli.stdin {

--- a/src/print/element.rs
+++ b/src/print/element.rs
@@ -1,5 +1,6 @@
 use quote::quote;
 use syn::{
+    LitStr,
     spanned::Spanned as _,
     token::{Dot, Pound},
 };
@@ -8,8 +9,8 @@ use crate::{
     line_length::{block_len, element_attrs_len},
     print::Printer,
     vendor::ast::{
-        Attribute, AttributeType, Element, ElementBody, HtmlName, HtmlNameFragment,
-        HtmlNameOrMarkup, HtmlNamePunct, Toggler,
+        Attribute, AttributeType, Element, ElementBody, HtmlLit, HtmlName, HtmlNameFragment,
+        HtmlNameOrMarkup, HtmlNamePunct, Markup, NoElement, Toggler,
     },
 };
 
@@ -50,6 +51,13 @@ impl<'a, 'b> Printer<'a, 'b> {
                 } => classes.push((dot_token, name, toggler)),
                 Attribute::Named { name, attr_type } => named_attrs.push((name, attr_type)),
             }
+        }
+
+        if self.options.tailwindcss {
+            classes = crate::tailwind::sort_by_class_name(classes, |(_, name, _)| match name {
+                HtmlNameOrMarkup::HtmlName(html_name) => Some(html_name.to_string()),
+                HtmlNameOrMarkup::Markup(_) => None,
+            });
         }
 
         let should_wrap = if let Some(element_len) =
@@ -152,6 +160,11 @@ impl<'a, 'b> Printer<'a, 'b> {
                     } else {
                         indent_level
                     };
+                    let value = if self.options.tailwindcss {
+                        maybe_sort_class_value(&name, value)
+                    } else {
+                        value
+                    };
                     self.print_markup(value, attr_indent, true)
                 }
                 AttributeType::Optional { toggler, .. } => {
@@ -211,6 +224,23 @@ impl<'a, 'b> Printer<'a, 'b> {
         } else {
             self.write(&value);
         }
+    }
+}
+
+/// Sorts the value of a `class="..."` attribute in place, when it is a plain string literal.
+/// Any other attribute name, or a value spliced/interpolated with Rust code, is left untouched.
+fn maybe_sort_class_value(name: &HtmlName, value: Markup<NoElement>) -> Markup<NoElement> {
+    if name.to_string() != "class" {
+        return value;
+    }
+    match value {
+        Markup::Lit(HtmlLit { lit }) => {
+            let sorted = crate::tailwind::sort_class_string(&lit.value());
+            Markup::Lit(HtmlLit {
+                lit: LitStr::new(&sorted, lit.span()),
+            })
+        }
+        other => other,
     }
 }
 

--- a/src/tailwind.rs
+++ b/src/tailwind.rs
@@ -1,0 +1,40 @@
+use std::sync::LazyLock;
+
+use rustywind_core::{PlainClassList, app::RustyWind, pattern_sorter};
+
+static SORTER: LazyLock<RustyWind> = LazyLock::new(RustyWind::default);
+
+/// Sorts a whitespace-separated string of classes, e.g. the value of a `class="..."` attribute.
+/// Returns the input unchanged if it isn't a plain class list (shouldn't happen for a literal
+/// string pulled straight out of source, but the validation is fallible so we fall back safely).
+pub fn sort_class_string(classes: &str) -> String {
+    match PlainClassList::parse(classes) {
+        Ok(list) => SORTER.sort_class_list(list),
+        Err(_) => classes.to_string(),
+    }
+}
+
+/// Reorders `items` by the Tailwind sort order of their class name, as returned by `class_name`.
+/// Leaves `items` untouched if any name is `None` (e.g. a dynamically spliced class name), since
+/// the resulting order would otherwise be arbitrary.
+pub fn sort_by_class_name<T>(items: Vec<T>, class_name: impl Fn(&T) -> Option<String>) -> Vec<T> {
+    let Some(names) = items.iter().map(&class_name).collect::<Option<Vec<_>>>() else {
+        return items;
+    };
+    let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+    let sorted = pattern_sorter::sort_classes(&refs);
+
+    let mut slots: Vec<Option<T>> = items.into_iter().map(Some).collect();
+    sorted
+        .into_iter()
+        .map(|class| {
+            let index = refs
+                .iter()
+                .position(|candidate| std::ptr::eq(*candidate, class))
+                .expect("sorted class must originate from the input refs");
+            slots[index]
+                .take()
+                .expect("each input consumed exactly once")
+        })
+        .collect()
+}


### PR DESCRIPTION
Adds an opt-in `--tailwindcss` flag that sorts classes using [`rustywind_core`](https://crates.io/crates/rustywind_core).

Handles both ways maud lets you write classes:

- `class="foo bar baz"` string-literal attributes
- `.foo.bar[toggler]` dot-shorthand syntax
